### PR TITLE
Pull chef/mlsa into it's own repo

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,0 +1,20 @@
+# Slack channel in Chef Software slack to send notifications about build failures, etc
+slack:
+  notify_channel:
+    - releng-notify
+
+
+habitat_packages:
+  - mlsa
+
+github:
+  delete_branch_on_merge: true
+  minor_bump_labels:
+     - "Version: Bump Minor"
+
+promote:
+  actions:
+    - built_in:promote_habitat_packages
+
+merge_actions:
+  - built_in:trigger_habitat_package_build

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Order is important. The last matching pattern has the most precedence.
+
+* @chef/jex

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.DS_Store
+
+# Habitat
+results/
+.studiorc
+
+# Editor
+.vscode/settings.json
+.vscode/launch.json
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Chef Online Master License and Services Agreement
+Legal requires us to have customers agree to the MLSA for proprietary software which is available from the Habitat public depot. This package is designed to be a dependency for any A2 Habitat components. It expects the `run` hook for each component to call the `accept` script which blocks unless the the running service config sets `mlsa.accept` to `true`, indicating the MLSA has been accepted.
+
+## Usage
+To use this package you need to add it to your plan, add the key/values show below to your `default.toml`, and call it in your `run` hook(s).
+
+### plan.sh
+```bash
+pkg_name=example
+pkg_origin=chef
+pkg_version=0.1.0
+pkg_description="My Example Service"
+pkg_license=('Proprietary')
+pkg_deps=(
+  chef/mlsa
+)
+```
+
+### default.toml
+```toml
+[mlsa]
+accept = false
+```
+
+### run hook
+```sh
+#!/bin/sh
+# Call the script to block until user accepts the MLSA via the package's config
+{{pkgPathFor "chef/mlsa"}}/bin/accept {{cfg.mlsa.accept}}
+```

--- a/accept
+++ b/accept
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Block if the MLSA was not accepted
+if ! [[ "${1}" == "true" || "${1}" == "1" ]] ; then
+  cat <<EOF
+=========================================================================
+
+Use of this Software is subject to the terms of the Chef Online Master
+License and Services Agreement. You can find the latest copy of the
+agreement here:
+
+https://www.chef.io/online-master-agreement
+
+=========================================================================
+EOF
+
+  # TO INFINITY AND BEYOND!
+  while true
+  do
+    sleep 5
+  done
+fi

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,19 @@
+pkg_name=mlsa
+pkg_origin=chef
+pkg_version=1.0.1
+pkg_description="Chef Online Master License and Services Agreement"
+pkg_upstream_url="https://www.chef.io/online-master-agreement"
+pkg_maintainer="Chef Software Inc."
+pkg_license=('Proprietary')
+pkg_bin_dirs=(bin)
+pkg_deps=(
+  core/busybox-static
+)
+do_build() {
+  return 0
+}
+
+do_install() {
+  install -m 0755 "${SRC_PATH}/accept" "${pkg_prefix}/bin"
+  fix_interpreter "${pkg_prefix}/bin/accept" core/busybox-static bin/env
+}


### PR DESCRIPTION
Because both chef/a2 and chef/automate depend on this package, we create
a breaking circular dependency if this pkg is built with one of those
repositories.

Signed-off-by: Tom Duffield <tom@chef.io>