### PR TITLE
Rewrite in Go to avoid runtime deps

### DIFF
--- a/accept.go
+++ b/accept.go
@@ -1,8 +1,12 @@
-#!/usr/bin/env bash
+package main
 
-# Block if the MLSA was not accepted
-if ! [[ "${1}" == "true" || "${1}" == "1" ]] ; then
-  cat <<EOF
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+const licenseMsg = `
 =========================================================================
 
 Use of this Software is subject to the terms of the Chef Online Master
@@ -12,11 +16,14 @@ agreement here:
 https://www.chef.io/online-master-agreement
 
 =========================================================================
-EOF
+`
 
-  # TO INFINITY AND BEYOND!
-  while true
-  do
-    sleep 5
-  done
-fi
+func main() {
+	if len(os.Args) > 1 && (os.Args[1] == "true" || os.Args[1] == "1") {
+		os.Exit(0)
+	}
+	fmt.Print(licenseMsg)
+	for {
+		time.Sleep(5 * time.Second)
+	}
+}

--- a/plan.sh
+++ b/plan.sh
@@ -6,14 +6,13 @@ pkg_upstream_url="https://www.chef.io/online-master-agreement"
 pkg_maintainer="Chef Software Inc."
 pkg_license=('Proprietary')
 pkg_bin_dirs=(bin)
-pkg_deps=(
-  core/busybox-static
+pkg_build_deps=(
+  core/go
 )
 do_build() {
-  return 0
+  CGO_ENABLED=0 go build -ldflags '-s -w -extldflags "-static"' accept.go
 }
 
 do_install() {
   install -m 0755 "${SRC_PATH}/accept" "${pkg_prefix}/bin"
-  fix_interpreter "${pkg_prefix}/bin/accept" core/busybox-static bin/env
 }


### PR DESCRIPTION
Depending on busybox-static means that any service that depends on
chef/mlsa will have busybox in their path. This PR replaces the shell
script with a small Go program that should be equivalent.

One bummer is that the go binary is actually pretty large even after
stripping. One alternative would be to just use C, but this seemed
more easily maintainable by a broader group of Chef developers over
time.

Signed-off-by: Steven Danna <steve@chef.io>